### PR TITLE
Fix resolution bug in datetime2year_float

### DIFF
--- a/cfr/utils.py
+++ b/cfr/utils.py
@@ -315,7 +315,7 @@ def datetime2year_float(date, resolution='month'):
     day = [d.day for d in date]
     if resolution == 'month': day = np.ones(np.size(day))
 
-    year_float = ymd2year_float(year, month, day)
+    year_float = ymd2year_float(year, month, day, resolution)
 
     return year_float
 


### PR DESCRIPTION
There is a bug in the conversion from datetimes to years in floats. Daily resolution is not supported, only monthly, because the resolution argument is not propagated into ymd2year_float. This is fixed in this PR.